### PR TITLE
NameHashValueHandler for resolving the binding hash to the shader resource binding name

### DIFF
--- a/modules/decima-ext-model-exporter/src/main/java/com/shade/decima/ui/data/viewer/model/ModelViewer.java
+++ b/modules/decima-ext-model-exporter/src/main/java/com/shade/decima/ui/data/viewer/model/ModelViewer.java
@@ -13,6 +13,8 @@ import javax.swing.*;
 
 @ValueViewerRegistration({
     @Selector(type = @Type(name = "MeshResourceBase")),
+    @Selector(type = @Type(name = "LodMeshResourcePart")),
+    @Selector(type = @Type(name = "MultiMeshResourcePart")),
     @Selector(type = @Type(name = "ArtPartsDataResource"), game = {GameType.DS, GameType.DSDC}),
     @Selector(type = @Type(name = "ArtPartsSubModelResource"), game = {GameType.DS, GameType.DSDC}),
     @Selector(type = @Type(name = "ArtPartsSubModelWithChildrenResource"), game = {GameType.DS, GameType.DSDC}),

--- a/modules/decima-ext-model-exporter/src/main/java/com/shade/decima/ui/data/viewer/model/isr/SceneSerializer.java
+++ b/modules/decima-ext-model-exporter/src/main/java/com/shade/decima/ui/data/viewer/model/isr/SceneSerializer.java
@@ -118,6 +118,8 @@ public class SceneSerializer {
                     serializeModelPartResource(task.split(1), node, object, file, project, context);
                 case "LodMeshResource" ->
                     serializeLodMeshResource(task.split(1), node, object, file, project, context);
+                case "LodMeshResourcePart", "MultiMeshResourcePart" ->
+                    serializeMeshResourcePart(task.split(1), node, object, file, project, context);
                 case "MultiMeshResource" ->
                     serializeMultiMeshResource(task.split(1), node, object, file, project, context);
                 case "StaticMeshInstance" ->
@@ -415,6 +417,17 @@ public class SceneSerializer {
                 }
             }
         }
+    }
+
+    private static void serializeMeshResourcePart(
+        @NotNull ProgressMonitor monitor,
+        @NotNull Node root,
+        @NotNull RTTIObject object,
+        @NotNull RTTICoreFile file,
+        @NotNull Project project,
+        @NotNull Context context
+    ) throws IOException {
+        root.add(serialize(monitor, object.ref("Mesh"), file, project, context));
     }
 
     private static void serializeModelPartResource(

--- a/modules/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/TextureViewer.java
+++ b/modules/decima-ext-texture-viewer/src/main/java/com/shade/decima/ui/data/viewer/texture/TextureViewer.java
@@ -47,6 +47,7 @@ import java.util.stream.IntStream;
     @Selector(type = @Type(name = "ImageMapEntry")),
     @Selector(type = @Type(name = "ButtonIcon")),
     @Selector(type = @Type(name = "MenuStreamingTexture")),
+    @Selector(type = @Type(name = "UITextureBindingOverride")),
     @Selector(type = @Type(type = HwTexture.class))
 })
 public class TextureViewer implements ValueViewer {
@@ -130,7 +131,7 @@ public class TextureViewer implements ValueViewer {
             case "TextureBindingWithHandle", "ShaderTextureBinding" -> {
                 return getTextureInfo(object.ref("TextureResource"), project, file, object.i32("PackedData"));
             }
-            case "TextureSetEntry", "ImageMapEntry", "ButtonIcon", "MenuStreamingTexture" -> {
+            case "TextureSetEntry", "ImageMapEntry", "ButtonIcon", "MenuStreamingTexture", "UITextureBindingOverride" -> {
                 return getTextureInfo(object.ref("Texture"), project, file, 0);
             }
             case "TextureSet" -> {

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/GGUUIDValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/GGUUIDValueHandler.java
@@ -6,7 +6,7 @@ import com.shade.decima.model.rtti.objects.RTTIObject;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
-import com.shade.platform.ui.controls.TextAttributes;
+import com.shade.platform.ui.controls.CommonTextAttributes;
 import com.shade.util.NotNull;
 import com.shade.util.Nullable;
 
@@ -19,7 +19,7 @@ public class GGUUIDValueHandler extends ObjectValueHandler {
     @NotNull
     @Override
     public Decorator getDecorator(@NotNull RTTIType<?> type) {
-        return (value, component) -> component.append("{%s}".formatted(RTTIUtils.uuidToString((RTTIObject) value)), TextAttributes.REGULAR_ATTRIBUTES);
+        return (value, component) -> component.append("{%s}".formatted(RTTIUtils.uuidToString((RTTIObject) value)), CommonTextAttributes.NUMBER_ATTRIBUTES);
     }
 
     @Nullable

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ImageMapEntryValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ImageMapEntryValueHandler.java
@@ -7,6 +7,9 @@ import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
 import com.shade.platform.ui.controls.TextAttributes;
 import com.shade.util.NotNull;
+import com.shade.util.Nullable;
+
+import javax.swing.*;
 
 @ValueHandlerRegistration(id = "imageMapEntry", name = "Image ID", value = {
     @Selector(type = @Type(name = "ImageMapEntry"))
@@ -16,5 +19,11 @@ public class ImageMapEntryValueHandler extends ObjectValueHandler {
     @Override
     public Decorator getDecorator(@NotNull RTTIType<?> type) {
         return (value, component) -> component.append(((RTTIObject) value).str("ID"), TextAttributes.REGULAR_ATTRIBUTES);
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon(@NotNull RTTIType<?> type) {
+        return UIManager.getIcon("Node.textureIcon");
     }
 }

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ImageMapEntryValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ImageMapEntryValueHandler.java
@@ -5,7 +5,7 @@ import com.shade.decima.model.rtti.objects.RTTIObject;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
-import com.shade.platform.ui.controls.TextAttributes;
+import com.shade.platform.ui.controls.CommonTextAttributes;
 import com.shade.util.NotNull;
 import com.shade.util.Nullable;
 
@@ -18,7 +18,13 @@ public class ImageMapEntryValueHandler extends ObjectValueHandler {
     @NotNull
     @Override
     public Decorator getDecorator(@NotNull RTTIType<?> type) {
-        return (value, component) -> component.append(((RTTIObject) value).str("ID"), TextAttributes.REGULAR_ATTRIBUTES);
+        return (value, component) -> component.append("\"%s\"".formatted(getText(type, value)), CommonTextAttributes.STRING_TEXT_ATTRIBUTES);
+    }
+
+    @NotNull
+    @Override
+    public String getText(@NotNull RTTIType<?> type, @NotNull Object value) {
+        return ((RTTIObject) value).str("ID");
     }
 
     @Nullable

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/MeshResourcePartHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/MeshResourcePartHandler.java
@@ -1,0 +1,32 @@
+package com.shade.decima.ui.data.handlers;
+
+import com.shade.decima.model.rtti.RTTIType;
+import com.shade.decima.model.rtti.objects.RTTIObject;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
+import com.shade.util.NotNull;
+import com.shade.util.Nullable;
+
+import javax.swing.*;
+
+@ValueHandlerRegistration(id = "meshPart", name = "Mesh part", value = {
+    @Selector(type = @Type(name = "MultiMeshResourcePart")),
+    @Selector(type = @Type(name = "LodMeshResourcePart"))
+})
+public class MeshResourcePartHandler extends ObjectValueHandler {
+    @Nullable
+    @Override
+    public Decorator getDecorator(@NotNull RTTIType<?> type) {
+        return (value, component) -> {
+            final RTTIObject obj = (RTTIObject) value;
+            ReferenceValueHandler.INSTANCE.getDecorator(type).decorate(obj.get("Mesh"), component);
+        };
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon(@NotNull RTTIType<?> type) {
+        return UIManager.getIcon("Node.modelIcon");
+    }
+}

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ModelValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ModelValueHandler.java
@@ -11,9 +11,15 @@ import javax.swing.*;
 
 @ValueHandlerRegistration(id = "model", name = "Model", value = {
     @Selector(type = @Type(name = "ModelResource")),
-    @Selector(type = @Type(name = "MeshResourceBase")),
+    @Selector(type = @Type(name = "MeshResourceBase"))
 })
 public class ModelValueHandler extends ObjectValueHandler {
+    @NotNull
+    @Override
+    public Decorator getDecorator(@NotNull RTTIType<?> type) {
+        return (value, component) -> ObjectWithNameValueHandler.INSTANCE.getDecorator(type).decorate(value, component);
+    }
+
     @Nullable
     @Override
     public Icon getIcon(@NotNull RTTIType<?> type) {

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/NameHashValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/NameHashValueHandler.java
@@ -1,0 +1,399 @@
+package com.shade.decima.ui.data.handlers;
+
+import com.shade.decima.model.rtti.RTTIType;
+import com.shade.decima.model.util.hash.CRC32C;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Field;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
+import com.shade.platform.model.util.IOUtils;
+import com.shade.platform.ui.controls.CommonTextAttributes;
+import com.shade.util.NotNull;
+
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@ValueHandlerRegistration(id = "nameHash", name = "Name Hash", value = {
+    @Selector(field = @Field(type = "ShaderTextureBinding", field = "BindingNameHash")),
+    @Selector(field = @Field(type = "ShaderTextureBinding", field = "BindingSwizzleNameHash")),
+    @Selector(field = @Field(type = "ShaderTextureBinding", field = "SamplerNameHash")),
+    @Selector(field = @Field(type = "ShaderVariableBinding", field = "BindingNameHash")),
+    @Selector(field = @Field(type = "ShaderVariableBinding", field = "VariableIDHash"))
+})
+public class NameHashValueHandler extends NumberValueHandler {
+    public static final NameHashValueHandler INSTANCE = new NameHashValueHandler();
+
+    private static final Map<Integer, String> LOOKUP;
+
+    static {
+        ArrayList<String> knownNames = new ArrayList<String>();
+
+        // TextureBindings: BindingNameHash
+        for (String n : Arrays.asList("BLACK", "WHITE", "RED", "GREEN", "BLUE", "CYAN", "MAGENTA", "YELLOW", "SKIN")) {
+            for (String t : Arrays.asList("Color", "Normal", "NormalColor")) {
+                knownNames.add("inSampler_%s_TextureSet%s".formatted(n,t));
+            }
+        }
+        for (String n : Arrays.asList("Base_Set", "Base_Texture_Set", "Base_TextureSet", "Color_TextureSet",
+                                      "Decal_Set", "Eyes_Teeth", "Fur_TextureSet", "FurDetail_Textureset",
+                                      "HeadCap_TextureSet", "Hair_LUT", "Hair_Paint_Set",
+                                      "Main_TextureSet", "Shared_Set", "textureset",
+                                      "WrinkleMap_01_Set", "WrinkleMap_02_Set")) {
+            for (String t : Arrays.asList("Alpha",
+                                          "AO", "AORoughnessReflectance",
+                                          "Color", "ColorAlpha", "ColorReflectance", "ColorRoughness",
+                                          "Height",
+                                          "Incandescence",
+                                          "Mask", "Mask_Alpha", "MaskReflectance", "MaskRoughness", 
+                                          "Misc_01", "Misc_01AO", "Misc_01Reflectance", "Misc_01Roughness",
+                                          "Normal", "NormalReflectance", "NormalRoughness",
+                                          "Reflectance", "ReflectanceAO", 
+                                          "Roughness", "RoughnessReflectanceAO",
+                                          "Translucency_Amount", "Translucency_Diffusion")) {
+                knownNames.add("inSampler_%s%s".formatted(n,t));
+            }
+        }
+        for (int i=0; i<20; i++) {
+            knownNames.add("inSampler%d".formatted(i));
+            knownNames.add("Layer_Wet_Character_inSampler%d".formatted(i));
+            knownNames.add("Layer_Wet_Robot_inSampler%d".formatted(i));
+        }
+        knownNames.addAll(Arrays.asList(
+            "AmbientBRDFTexture",
+            "VolumeLightVolumeTexture",
+            "DepthColorizeTexture",
+            "ShadowmapTexture",
+            "SunShadowmapTextureA",
+            "SunShadowmapTextureB",
+            "SunShadowmapTextureLongDistance",
+            "SunCompartmentTextureC0",
+            "SunCompartmentTextureC1",
+            "NormalTexture",
+            "ReflectanceTexture",
+            "AttributesTexture",
+            "DepthTexture",
+            "DiffuseLightTexture",
+            "SceneCubemapTexture",
+            "LocalCubemapTexture0",
+            "LocalCubemapTexture1",
+            "IV0Terrain",
+            "IV0Height",
+            "IV0SkyVis",
+            "IV00Aleph",
+            "IV00Beth",
+            "IV00Axis",
+            "IV01Aleph",
+            "IV01Beth",
+            "IV01Axis",
+            "IV02Aleph",
+            "IV02Beth",
+            "IV02Axis",
+            "ForceFieldsTexture0",
+            "ForceFieldsTexture1",
+            "ForceFieldsTexture2",
+            "BlendMatrices",
+            "inSampler_LightSource",
+            "inSampler_LightSourceDepth",
+            "inSampler_MuscleMaskMask_Alpha",
+            "inSampler_FakeSpecRamp",
+            "inSampler_Fake_Spec_Ramp",
+            "inSampler_Fake_Specular_Ramp",
+            "inSampler_Base_TextureSet",
+            "inSampler_Color_TextureSet",
+            "inSampler_NoiseBreakup_TextureSetColor",
+            "inSampler_TextureSet4AO",
+            "inSampler_TextureSet4Normal",
+            "inSampler_TextureSet6Mask",
+            "inSampler_TextureSet27Height",
+            "inSampler_TextureSet27Normal",
+            "inSampler_TextureSet8Color",
+            "inSampler_TextureSet8Normal",
+            "inSampler_TextureSet8Height",
+            "inSampler_Cracks_Set1Height",
+            "inSampler_Cracks_Set1Normal",
+            "inSampler_Lumps_Set1NormalColorHeight",
+            "RampTexture89313432",
+            "RampTexture833145267",
+            "RampTexture906088057",
+            "RampTexture1110498300",
+            "WorldData_Topo_Roads_Topo_Water_Topo_Objects_Ecotope_Effect"
+        ));
+
+        // TextureBindings: BindingSwizzleNameHash
+        for (String s : knownNames.toArray(new String[knownNames.size()])) {
+            knownNames.add(s + "Swizzle");
+        }
+
+        // TextureBindings: SamplerNameHash
+        for (int i=0; i<200; i++) {
+            knownNames.add("GlobalSamplers_%d".formatted(i));
+        }
+        knownNames.addAll(Arrays.asList(
+            "ShadowmapSampler",
+            "SunShadowmapSampler",
+            "SunLongDistanceSampler"
+        ));
+
+        // VariableBindings: BindingNameHash
+        for (int i=0; i<100; i++) {
+            knownNames.add("inVariable%d".formatted(i));
+            knownNames.add("Layer_Wet_Character_inVariable%d".formatted(i));
+            knownNames.add("Layer_Wet_Robot_inVariable%d".formatted(i));
+        }
+        knownNames.addAll(Arrays.asList(
+            // Resource Bindings
+            "Scratch_PerFrame",
+            "Scratch_PerPass",
+            "Scratch_PerView",
+            "Scratch_PerBatch",
+            "Scratch_PerInstance",
+            "ShaderInstance_PerInstance",
+
+            // Buffer Definitions
+            // cbuffer Scratch_PerFrame
+            // struct.GlobalConstants {
+            "ColorizeValue",
+            "AlbedoBiasScaleName",
+            "ZoneReflectionIntensity",
+            "PerTileVolumeTransformScale",
+            "PerTileVolumeTransformOffsetName",
+            "Temperature",
+            "Precipitation",
+            "Wetness",
+            "CurTime",
+            "DepthDirection",
+            "MaterialRefColorFilter",
+            "ShaderDebugMask",
+            "PlayerSpeed",
+            "WorldMinHeight",
+            "WorldMaxHeight",
+            "PlayerPosition",
+            // } GlobalConstants
+
+            // cbuffer Scratch_PerView
+            // struct.ViewConstants {
+            "View",
+            "Proj",
+            "ViewProj",
+            "InvView",
+            "OldViewProj",
+            "DepthReconstructMatrix",
+            "HalfResDepthReconstructMatrix",
+            "QuarterResDepthReconstructMatrix",
+            "Viewport",
+            "WPOSScaleOffset",
+            "MVScaleBias",
+            "PixelSize",
+            "ViewPos",
+            "HPOSReconstructScaleOffset",
+            "FloatingOrigin",
+            // struct.GlobalRenderVariablesSRT {
+            "GlobalRenderVariable0",
+            "GlobalRenderVariable1",
+            "GlobalRenderVariable2",
+            "GlobalRenderVariable3",
+            "GlobalRenderVariable4",
+            "GlobalRenderVariable5",
+            "GlobalRenderVariable6",
+            "GlobalRenderVariable7",
+            "GlobalRenderVariable8",
+            "GlobalRenderVariable9",
+            "GlobalRenderVariable10",
+            "GlobalRenderVariable11",
+            "GlobalRenderVariable12",
+            "GlobalRenderVariable13",
+            "GlobalRenderVariable14",
+            "GlobalRenderVariable15",
+            // } GlobalRenderVariables
+            "ForceFieldsRegionOffset0",
+            "ForceFieldsRegionOffset1",
+            "ForceFieldsRegionOffset2",
+            "ForceFieldsRegionScale0",
+            "ForceFieldsRegionScale1",
+            "ForceFieldsRegionScale2",
+            "LodDistanceMul",
+            "VolumeLightDepthRange",
+            "PackedLightIndices",
+            "VantageRenderScaler",
+            // } ViewConstants
+
+            // cbuffer Scratch_PerInstance
+            // struct.RasterizerVariables {
+            "ModelViewProj",
+            "ModelView",
+            "OldModelViewProj",
+            "Model",
+            "InstanceCustomData",
+            // } RasterizerVariables
+            // struct.RasterizerVariablesExtended {
+            "InvModel",
+            "CameraFacingMatrix",
+            "InvModelView",
+            "OldModel",
+            "InvModelViewProj",
+            // } RasterizerVariablesExtended
+            // struct.SkinnedMeshInstanceData {
+            "BlendMatrixOffset",
+            "PrevBlendMatrixOffset",
+            "Padding0",
+            "Padding1",
+            // } SkinnedMeshInstanceData
+            // struct.ShadowMapConstants {
+            "Transform",
+            "ShadowFacingMatrix",
+            "Bias",
+            // } ShadowMapConstants
+
+            // cbuffer Scratch_PerPass
+            // struct.MetaLight {
+            "Position",
+            "LightDirection",
+            "LightDirectionUp",
+            "LightAreaParams",
+            "DiffuseColor",
+            "AttenuationDot",
+            "AttenuationSmooth",
+            "LightVPLPosition",
+            "CameraToProjectiveTexture",
+            "CameraToLightMatrix",
+            "LightToCameraMatrix",
+            "TanHalfConeAngle",
+            "LightRange",
+            "DepthMin",
+            "DepthMax",
+            "DiffuseAndSpecularMultiplier",
+            "Padding",
+            // } LightConstants[8]
+            // struct.LightingMaterial {
+            "SpecularColor",
+            "Auxillary",
+            // } MaterialConstants[6]
+            // struct.ShadowMapSampleConstants {
+            "CameraToShadowmap",
+            "LightToShadowmap",
+            "ShadowMapZScaleBias",
+            "ShadowIntensity",
+            // } ShadowMapSampleConstants[8]
+            // struct.SunShadowSampleConstants {
+            "CascadeInfo",
+            "mCameraToLongDistanceShadowMatrix",
+            "ExternalFadeoutOriginA",
+            "ExternalFadeoutHalfExtentA",
+            "ExternalFadeoutTransitionScaleA",
+            "ExternalFadeoutOriginB",
+            "ExternalFadeoutHalfExtentB",
+            "ExternalFadeoutTransitionScaleB",
+            "ExternalFadeoutOriginLD",
+            "ExternalFadeoutHalfExtentLD",
+            "ExternalFadeoutTransitionScaleLD",
+            "ExternalFadeoutOriginC0",
+            "ExternalFadeoutHalfExtentC0",
+            "ExternalFadeoutTransitionScaleC0",
+            "ExternalFadeoutOriginC1",
+            "ExternalFadeoutHalfExtentC1",
+            "ExternalFadeoutTransitionScaleC1",
+            // } SunShadowConstants
+            // struct.AtmosphericScattingCB {
+            "SunlightDirection",
+            "SkyColor",
+            "MieScatteringPhases",
+            "SunLightAbsorptionCoefficient",
+            "SkyFadeOffSunAngleMin",
+            "SkyFadeOffSunAngleMax",
+            "SunIntensityAngleFadeMin",
+            "SunIntensityAngleFadeMax",
+            "SkyZenithIntensity",
+            "SkyHorizonIntensity",
+            "SkyGradientPower",
+            "SkyBrightness",
+            "MieIntensityGradientPower",
+            "MieColorAbsorptionZenith",
+            "MieColorAbsorptionHorizon",
+            "MieColorGradientPower",
+            "MieBaseIntensity",
+            "MieLightShaftIntensity",
+            "HazeStartDistance",
+            "HazeEndDistance",
+            "HazeDensityCurvature",
+            "SunShapeIntensity",
+            "SunShapeSize",
+            "SunColorAbsorptionZenith",
+            "SunColorAbsorptionHorizon",
+            "SunColorAbsorptionGradientPower",
+            "SunsetStartAngle",
+            "SunsetAngleFadeRange",
+            "NewAtmosphereEnabled",
+            // } AtmosphereConstants
+            // struct.WaterInteractionSampleParams_Constant {
+            "AABB",
+            // } WaterInteractionSampleParams_Constant
+            // struct.SnowInteractionSampleParams_Constant {
+             "SnowDeformationAABB",
+             "SnowDeformationMaxDepth",
+            // } SnowInteractionSampleParams_Constant
+
+            // cbuffer Scratch_PerBatch
+            // struct struct.CubemapZone2SRTData_Constant {
+            "LocalCubemapParams",
+            // } CubeMapZoneData_Constant
+            // struct struct.ForwardPassIndirectConstants {
+            "LayeredIrradianceParam",
+            "LayeredIrradianceStrength",
+            "NormalStepScale",
+            "CommonTerrainParams",
+            "SkyColorAverage",
+            "SkyColorPX",
+            "SkyColorPY",
+            "IV0Region_Origin",
+            "IV0Region_BasisU",
+            "IV0Region_BasisV",
+            "IV0Region_BasisW",
+            "IV0Local_Min",
+            "IV0Local_Max",
+            "IV0Local_BorderFade",
+            "IV0HeightUnpackScale",
+            "IV0TerrainBase",
+            "IV0TerrainDeltaConfidence",
+            "IV00ColorScale",
+            "IV01ColorScale",
+            "IV02ColorScale",
+            "MinSkyvisValue"
+            // } ForwardPassIndirectConstants
+        ));
+
+        LOOKUP = knownNames.stream().collect(Collectors.toMap(
+            name -> CRC32C.calculate(name.getBytes(StandardCharsets.UTF_8)),
+            Function.identity()
+        ));
+    }
+
+    @NotNull
+    @Override
+    public Decorator getDecorator(@NotNull RTTIType<?> type) {
+        return (value, component) -> {
+            final String name = getText(type, value);
+            if (name.matches("[0-9A-F]{8}")) {
+                component.append(name, CommonTextAttributes.NUMBER_ATTRIBUTES);
+            } else {
+                component.append("\"%s\"".formatted(name), CommonTextAttributes.STRING_TEXT_ATTRIBUTES);
+            }
+        };
+    }
+
+    @NotNull
+    @Override
+    public String getText(@NotNull RTTIType<?> type, @NotNull Object value) {
+        final int hash = ((Number) value).intValue();
+        final String name = LOOKUP.get(hash);
+
+        if (name != null) {
+            return name;
+        } else {
+            return IOUtils.toHexDigits(hash, ByteOrder.BIG_ENDIAN);
+        }
+    }
+}

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/NameHashValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/NameHashValueHandler.java
@@ -11,8 +11,8 @@ import com.shade.util.NotNull;
 
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -35,29 +35,31 @@ public class NameHashValueHandler extends NumberValueHandler {
         // TextureBindings: BindingNameHash
         for (String n : Arrays.asList("BLACK", "WHITE", "RED", "GREEN", "BLUE", "CYAN", "MAGENTA", "YELLOW", "SKIN")) {
             for (String t : Arrays.asList("Color", "Normal", "NormalColor")) {
-                knownNames.add("inSampler_%s_TextureSet%s".formatted(n,t));
+                knownNames.add("inSampler_%s_TextureSet%s".formatted(n, t));
             }
         }
         for (String n : Arrays.asList("Base_Set", "Base_Texture_Set", "Base_TextureSet", "Color_TextureSet",
-                                      "Decal_Set", "Eyes_Teeth", "Fur_TextureSet", "FurDetail_Textureset",
-                                      "HeadCap_TextureSet", "Hair_LUT", "Hair_Paint_Set",
-                                      "Main_TextureSet", "Shared_Set", "textureset",
-                                      "WrinkleMap_01_Set", "WrinkleMap_02_Set")) {
+            "Decal_Set", "Eyes_Teeth", "Fur_TextureSet", "FurDetail_Textureset",
+            "HeadCap_TextureSet", "Hair_LUT", "Hair_Paint_Set",
+            "Main_TextureSet", "Shared_Set", "textureset",
+            "WrinkleMap_01_Set", "WrinkleMap_02_Set"
+        )) {
             for (String t : Arrays.asList("Alpha",
-                                          "AO", "AORoughnessReflectance",
-                                          "Color", "ColorAlpha", "ColorReflectance", "ColorRoughness",
-                                          "Height",
-                                          "Incandescence",
-                                          "Mask", "Mask_Alpha", "MaskReflectance", "MaskRoughness", 
-                                          "Misc_01", "Misc_01AO", "Misc_01Reflectance", "Misc_01Roughness",
-                                          "Normal", "NormalReflectance", "NormalRoughness",
-                                          "Reflectance", "ReflectanceAO", 
-                                          "Roughness", "RoughnessReflectanceAO",
-                                          "Translucency_Amount", "Translucency_Diffusion")) {
-                knownNames.add("inSampler_%s%s".formatted(n,t));
+                "AO", "AORoughnessReflectance",
+                "Color", "ColorAlpha", "ColorReflectance", "ColorRoughness",
+                "Height",
+                "Incandescence",
+                "Mask", "Mask_Alpha", "MaskReflectance", "MaskRoughness",
+                "Misc_01", "Misc_01AO", "Misc_01Reflectance", "Misc_01Roughness",
+                "Normal", "NormalReflectance", "NormalRoughness",
+                "Reflectance", "ReflectanceAO",
+                "Roughness", "RoughnessReflectanceAO",
+                "Translucency_Amount", "Translucency_Diffusion"
+            )) {
+                knownNames.add("inSampler_%s%s".formatted(n, t));
             }
         }
-        for (int i=0; i<20; i++) {
+        for (int i = 0; i < 20; i++) {
             knownNames.add("inSampler%d".formatted(i));
             knownNames.add("Layer_Wet_Character_inSampler%d".formatted(i));
             knownNames.add("Layer_Wet_Robot_inSampler%d".formatted(i));
@@ -129,7 +131,7 @@ public class NameHashValueHandler extends NumberValueHandler {
         }
 
         // TextureBindings: SamplerNameHash
-        for (int i=0; i<200; i++) {
+        for (int i = 0; i < 200; i++) {
             knownNames.add("GlobalSamplers_%d".formatted(i));
         }
         knownNames.addAll(Arrays.asList(
@@ -139,7 +141,7 @@ public class NameHashValueHandler extends NumberValueHandler {
         ));
 
         // VariableBindings: BindingNameHash
-        for (int i=0; i<100; i++) {
+        for (int i = 0; i < 100; i++) {
             knownNames.add("inVariable%d".formatted(i));
             knownNames.add("Layer_Wet_Character_inVariable%d".formatted(i));
             knownNames.add("Layer_Wet_Robot_inVariable%d".formatted(i));
@@ -332,8 +334,8 @@ public class NameHashValueHandler extends NumberValueHandler {
             "AABB",
             // } WaterInteractionSampleParams_Constant
             // struct.SnowInteractionSampleParams_Constant {
-             "SnowDeformationAABB",
-             "SnowDeformationMaxDepth",
+            "SnowDeformationAABB",
+            "SnowDeformationMaxDepth",
             // } SnowInteractionSampleParams_Constant
 
             // cbuffer Scratch_PerBatch
@@ -376,10 +378,10 @@ public class NameHashValueHandler extends NumberValueHandler {
     public Decorator getDecorator(@NotNull RTTIType<?> type) {
         return (value, component) -> {
             final String name = getText(type, value);
-            if (name.matches("[0-9A-F]{8}")) {
-                component.append(name, CommonTextAttributes.NUMBER_ATTRIBUTES);
-            } else {
+            if (LOOKUP.containsKey(((Number) value).intValue())) {
                 component.append("\"%s\"".formatted(name), CommonTextAttributes.STRING_TEXT_ATTRIBUTES);
+            } else {
+                component.append(name, CommonTextAttributes.NUMBER_ATTRIBUTES);
             }
         };
     }

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ObjectWithNameValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ObjectWithNameValueHandler.java
@@ -6,10 +6,10 @@ import com.shade.decima.model.rtti.objects.RTTIObject;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
-import com.shade.platform.ui.controls.TextAttributes;
+import com.shade.platform.ui.controls.CommonTextAttributes;
 import com.shade.util.NotNull;
 
-@ValueHandlerRegistration(id = "namedObject", name = "Named Object", value = {
+@ValueHandlerRegistration(id = "namedObject", name = "Named Object", order = 50, value = {
     @Selector(type = @Type(name = "Resource"), game = GameType.HZD),
     @Selector(type = @Type(name = "Property"), game = GameType.HZD),
     @Selector(type = @Type(name = "ResourceWithName"), game = GameType.DS),
@@ -17,10 +17,12 @@ import com.shade.util.NotNull;
     @Selector(type = @Type(name = "OrientationHelper"))
 })
 public class ObjectWithNameValueHandler extends ObjectValueHandler {
+    public static final ObjectWithNameValueHandler INSTANCE = new ObjectWithNameValueHandler();
+
     @NotNull
     @Override
     public Decorator getDecorator(@NotNull RTTIType<?> type) {
-        return (value, component) -> component.append(getText(type, value), TextAttributes.REGULAR_ATTRIBUTES);
+        return (value, component) -> component.append("\"%s\"".formatted(getText(type, value)), CommonTextAttributes.STRING_TEXT_ATTRIBUTES);
     }
 
     @NotNull

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ReferenceValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ReferenceValueHandler.java
@@ -7,6 +7,7 @@ import com.shade.decima.ui.data.ValueHandler;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
+import com.shade.platform.ui.controls.CommonTextAttributes;
 import com.shade.platform.ui.controls.TextAttributes;
 import com.shade.util.NotNull;
 import com.shade.util.Nullable;
@@ -24,12 +25,12 @@ public class ReferenceValueHandler implements ValueHandler {
     public Decorator getDecorator(@NotNull RTTIType<?> type) {
         return (value, component) -> {
             if (value instanceof RTTIReference.External ref) {
-                component.append(ref.path(), TextAttributes.REGULAR_ATTRIBUTES);
+                component.append(ref.path(), CommonTextAttributes.REFERENCE_ATTRIBUTES);
                 component.append(" : ", TextAttributes.REGULAR_ATTRIBUTES);
-                component.append(RTTIUtils.uuidToString(ref.uuid()), TextAttributes.REGULAR_ATTRIBUTES);
+                component.append("{%s}".formatted(RTTIUtils.uuidToString(ref.uuid())), CommonTextAttributes.NUMBER_ATTRIBUTES);
                 component.append(" (" + ref.kind() + ")", TextAttributes.GRAYED_ATTRIBUTES);
             } else if (value instanceof RTTIReference.Internal ref) {
-                component.append(RTTIUtils.uuidToString(ref.uuid()), TextAttributes.REGULAR_ATTRIBUTES);
+                component.append("{%s}".formatted(RTTIUtils.uuidToString(ref.uuid())), CommonTextAttributes.NUMBER_ATTRIBUTES);
                 component.append(" (" + ref.kind() + ")", TextAttributes.GRAYED_ATTRIBUTES);
             } else {
                 component.append("none", TextAttributes.REGULAR_ATTRIBUTES);

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ShaderTextureBindingValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ShaderTextureBindingValueHandler.java
@@ -23,7 +23,8 @@ public class ShaderTextureBindingValueHandler extends ObjectValueHandler {
             final int packedData = obj.i32("PackedData");
             final boolean isTextureSet = (packedData & 3) == 2;
             final String texturePurpose = PackingInfoHandler.getUsage(packedData >>> 2 & 0xf);
-            component.append("type = ", TextAttributes.REGULAR_ATTRIBUTES);
+            NameHashValueHandler.INSTANCE.getDecorator(type).decorate(obj.i32("BindingNameHash"), component);
+            component.append(", type = ", TextAttributes.REGULAR_ATTRIBUTES);
             if (isTextureSet) {
                 component.append("TextureSet, usage = ", TextAttributes.REGULAR_ATTRIBUTES);
                 component.append(texturePurpose, TextAttributes.REGULAR_BOLD_ATTRIBUTES);

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ShaderTextureBindingValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ShaderTextureBindingValueHandler.java
@@ -9,6 +9,8 @@ import com.shade.platform.ui.controls.TextAttributes;
 import com.shade.util.NotNull;
 import com.shade.util.Nullable;
 
+import javax.swing.*;
+
 @ValueHandlerRegistration(id = "textureBinding", name = "Texture Binding", value = {
     @Selector(type = @Type(name = "ShaderTextureBinding"))
 })
@@ -31,5 +33,11 @@ public class ShaderTextureBindingValueHandler extends ObjectValueHandler {
             }
             ReferenceValueHandler.INSTANCE.getDecorator(type).decorate(obj.get("TextureResource"), component);
         };
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon(@NotNull RTTIType<?> type) {
+        return UIManager.getIcon("Node.textureIcon");
     }
 }

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ShaderVariableBindingValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/ShaderVariableBindingValueHandler.java
@@ -1,0 +1,23 @@
+package com.shade.decima.ui.data.handlers;
+
+import com.shade.decima.model.rtti.RTTIType;
+import com.shade.decima.model.rtti.objects.RTTIObject;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
+import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
+import com.shade.util.NotNull;
+import com.shade.util.Nullable;
+
+@ValueHandlerRegistration(id = "variableBinding", name = "Variable Binding", value = {
+    @Selector(type = @Type(name = "ShaderVariableBinding"))
+})
+public class ShaderVariableBindingValueHandler extends ObjectValueHandler {
+    @Nullable
+    @Override
+    public Decorator getDecorator(@NotNull RTTIType<?> type) {
+        return (value, component) -> {
+            final RTTIObject obj = (RTTIObject) value;
+            NameHashValueHandler.INSTANCE.getDecorator(type).decorate(obj.i32("BindingNameHash"), component);
+        };
+    }
+}

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/TextureSetEntryValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/TextureSetEntryValueHandler.java
@@ -9,6 +9,8 @@ import com.shade.platform.ui.controls.TextAttributes;
 import com.shade.util.NotNull;
 import com.shade.util.Nullable;
 
+import javax.swing.*;
+
 @ValueHandlerRegistration(id = "textureUsage", name = "Texture Usage", value = {
     @Selector(type = @Type(name = "TextureSetEntry"))
 })
@@ -25,5 +27,11 @@ public class TextureSetEntryValueHandler extends ObjectValueHandler {
             component.append("%s, ".formatted(compressMethod), TextAttributes.REGULAR_ATTRIBUTES);
             PackingInfoHandler.INSTANCE.getDecorator(type).decorate(packingInfo, component);
         };
+    }
+
+    @Nullable
+    @Override
+    public Icon getIcon(@NotNull RTTIType<?> type) {
+        return UIManager.getIcon("Node.textureIcon");
     }
 }

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/TextureValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/TextureValueHandler.java
@@ -1,9 +1,11 @@
 package com.shade.decima.ui.data.handlers;
 
 import com.shade.decima.model.rtti.RTTIType;
+import com.shade.decima.model.rtti.objects.RTTIObject;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Selector;
 import com.shade.decima.ui.data.registry.ValueHandlerRegistration.Type;
+import com.shade.platform.ui.controls.CommonTextAttributes;
 import com.shade.util.NotNull;
 import com.shade.util.Nullable;
 
@@ -11,8 +13,30 @@ import javax.swing.*;
 
 @ValueHandlerRegistration(id = "texture", name = "Texture", value = {
     @Selector(type = @Type(name = "Texture")),
+    @Selector(type = @Type(name = "MenuStreamingTexture")),
+    @Selector(type = @Type(name = "UITextureBindingOverride"))
 })
 public class TextureValueHandler extends ObjectValueHandler {
+    @NotNull
+    @Override
+    public Decorator getDecorator(@NotNull RTTIType<?> type) {
+        return (value, component) -> component.append("\"%s\"".formatted(getText(type, value)), CommonTextAttributes.STRING_TEXT_ATTRIBUTES);
+    }
+
+    @NotNull
+    @Override
+    public String getText(@NotNull RTTIType<?> type, @NotNull Object value) {
+        final RTTIObject obj = (RTTIObject) value;
+        final String str;
+        switch (type.getTypeName()) {
+            case "MenuStreamingTexture", "UITextureBindingOverride" -> {
+                str = obj.str("TextureName");
+            }
+            default -> str = obj.str("Name");
+        }
+        return str;
+    }
+
     @Nullable
     @Override
     public Icon getIcon(@NotNull RTTIType<?> type) {

--- a/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/TextureValueHandler.java
+++ b/modules/decima-ui/src/main/java/com/shade/decima/ui/data/handlers/TextureValueHandler.java
@@ -27,14 +27,10 @@ public class TextureValueHandler extends ObjectValueHandler {
     @Override
     public String getText(@NotNull RTTIType<?> type, @NotNull Object value) {
         final RTTIObject obj = (RTTIObject) value;
-        final String str;
-        switch (type.getTypeName()) {
-            case "MenuStreamingTexture", "UITextureBindingOverride" -> {
-                str = obj.str("TextureName");
-            }
-            default -> str = obj.str("Name");
-        }
-        return str;
+        return switch (type.getTypeName()) {
+            case "MenuStreamingTexture", "UITextureBindingOverride" -> obj.str("TextureName");
+            default -> obj.str("Name");
+        };
     }
 
     @Nullable

--- a/modules/platform-ui/src/main/java/com/shade/platform/ui/controls/CommonTextAttributes.java
+++ b/modules/platform-ui/src/main/java/com/shade/platform/ui/controls/CommonTextAttributes.java
@@ -9,4 +9,5 @@ public interface CommonTextAttributes {
     TextAttributes NUMBER_ATTRIBUTES = new TextAttributes(UIColor.named("Text.numberForeground"), TextAttributes.Style.PLAIN);
     TextAttributes STRING_TEXT_ATTRIBUTES = new TextAttributes(UIColor.named("Text.stringForeground"), TextAttributes.Style.PLAIN);
     TextAttributes STRING_ESCAPE_ATTRIBUTES = new TextAttributes(UIColor.named("Text.stringEscapeForeground"), TextAttributes.Style.BOLD);
+    TextAttributes REFERENCE_ATTRIBUTES = new TextAttributes(UIColor.named("Text.referenceForeground"), TextAttributes.Style.PLAIN);
 }

--- a/modules/platform-ui/src/main/resources/themes/FlatDarkLaf.properties
+++ b/modules/platform-ui/src/main/resources/themes/FlatDarkLaf.properties
@@ -21,6 +21,7 @@ Text.identifierForeground = #ff8e8e
 Text.numberForeground = #4dacf0
 Text.stringForeground = #62a362
 Text.stringEscapeForeground = #e0957b
+Text.referenceForeground = #50f0f0
 
 # Memory Indicator
 MemoryIndicator.foreground = @foreground

--- a/modules/platform-ui/src/main/resources/themes/FlatDarkLaf.properties
+++ b/modules/platform-ui/src/main/resources/themes/FlatDarkLaf.properties
@@ -21,7 +21,7 @@ Text.identifierForeground = #ff8e8e
 Text.numberForeground = #4dacf0
 Text.stringForeground = #62a362
 Text.stringEscapeForeground = #e0957b
-Text.referenceForeground = #50f0f0
+Text.referenceForeground = #38c0c0
 
 # Memory Indicator
 MemoryIndicator.foreground = @foreground

--- a/modules/platform-ui/src/main/resources/themes/FlatLaf.properties
+++ b/modules/platform-ui/src/main/resources/themes/FlatLaf.properties
@@ -58,7 +58,7 @@ Text.identifierForeground = #800000
 Text.numberForeground = #0000ff
 Text.stringForeground = #008000
 Text.stringEscapeForeground = #000080
-Text.referenceForeground = #308080
+Text.referenceForeground = #00c0c0
 
 # Memory Indicator
 MemoryIndicator.foreground = lighten(@foreground,40%)

--- a/modules/platform-ui/src/main/resources/themes/FlatLaf.properties
+++ b/modules/platform-ui/src/main/resources/themes/FlatLaf.properties
@@ -58,6 +58,7 @@ Text.identifierForeground = #800000
 Text.numberForeground = #0000ff
 Text.stringForeground = #008000
 Text.stringEscapeForeground = #000080
+Text.referenceForeground = #308080
 
 # Memory Indicator
 MemoryIndicator.foreground = lighten(@foreground,40%)


### PR DESCRIPTION
Added NameHashValueHandler, which creates crc32 lookup table for the shader resource binding names
Colorized some decorators for better readability
![NameHashValueHandler](https://github.com/ShadelessFox/decima/assets/49768797/555cff3e-ce46-4044-8215-bb25b42f0907)
Extended ModelViewer for *MeshResourcePart types
Extended texture decorator and viewer:
Added selector for "MenuStreamingTexture" and "UITextureBindingOverride" types
![MultiMeshParts+MenuStreamingTextures](https://github.com/ShadelessFox/decima/assets/49768797/9f22927f-f526-4116-99c6-8452516f9cb0)
