### PR TITLE
GGUUID: Display and parse bytes in their on-disk order

### DIFF
--- a/decima-model/src/main/java/com/shade/decima/model/rtti/RTTIUtils.java
+++ b/decima-model/src/main/java/com/shade/decima/model/rtti/RTTIUtils.java
@@ -11,9 +11,9 @@ public class RTTIUtils {
     @NotNull
     public static String uuidToString(@NotNull RTTIObject o) {
         return "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x".formatted(
-            o.i8("Data3"), o.i8("Data2"), o.i8("Data1"), o.i8("Data0"),
-            o.i8("Data5"), o.i8("Data4"),
-            o.i8("Data7"), o.i8("Data6"),
+            o.i8("Data0"), o.i8("Data1"), o.i8("Data2"), o.i8("Data3"),
+            o.i8("Data4"), o.i8("Data5"),
+            o.i8("Data6"), o.i8("Data7"),
             o.i8("Data8"), o.i8("Data9"),
             o.i8("Data10"), o.i8("Data11"), o.i8("Data12"), o.i8("Data13"), o.i8("Data14"), o.i8("Data15")
         );

--- a/decima-ui/src/main/java/com/shade/decima/ui/data/editors/GGUUIDValueEditor.java
+++ b/decima-ui/src/main/java/com/shade/decima/ui/data/editors/GGUUIDValueEditor.java
@@ -82,14 +82,14 @@ public class GGUUIDValueEditor extends BaseValueEditor<RTTIObject, JTextField> {
         final long lsb = uuid.getLeastSignificantBits();
         final RTTIObject object = type.instantiate();
 
-        object.set("Data3", (byte) (msb >>> 56));
-        object.set("Data2", (byte) (msb >>> 48));
-        object.set("Data1", (byte) (msb >>> 40));
-        object.set("Data0", (byte) (msb >>> 32));
-        object.set("Data5", (byte) (msb >>> 24));
-        object.set("Data4", (byte) (msb >>> 16));
-        object.set("Data7", (byte) (msb >>> 8));
-        object.set("Data6", (byte) (msb));
+        object.set("Data0", (byte) (msb >>> 56));
+        object.set("Data1", (byte) (msb >>> 48));
+        object.set("Data2", (byte) (msb >>> 40));
+        object.set("Data3", (byte) (msb >>> 32));
+        object.set("Data4", (byte) (msb >>> 24));
+        object.set("Data5", (byte) (msb >>> 16));
+        object.set("Data6", (byte) (msb >>> 8));
+        object.set("Data7", (byte) (msb));
         object.set("Data8", (byte) (lsb >>> 56));
         object.set("Data9", (byte) (lsb >>> 48));
         object.set("Data10", (byte) (lsb >>> 40));


### PR DESCRIPTION
`GGUUID` is a struct of 16 sequential `uint8` fields (`Data0..Data15`) at offsets 0..15 in the binary file. `RTTIUtils.uuidToString` was reversing `Data0..3`, `Data4..5` and `Data6..7` (Microsoft mixed-endian GUID convention), so the displayed UUID did not match the bytes seen in a hex view of the `.core` file.

The rest of the codebase already treats this struct as raw bytes — see `MurmurHashValueHandler` (sequential `Data0..Data15`) and the `GGUUID` `HashMap`-key `CRC32C` hasher in `RTTITypeHashMap` (also `Data0..Data15` in order).

Reproduction (DS1): a SimpleText whose binary bytes are `36 b1 a4 48 cf 56 40 93 8d f3 88 c3 e7 c4 2f 89` was being displayed as `48a4b136-56cf-9340-8df3-88c3e7c42f89` instead of `36b1a448-cf56-4093-8df3-88c3e7c42f89`.

### Changes
- `RTTIUtils.uuidToString`: emit `Data0..Data15` in order.
- `GGUUIDValueEditor.fromString`: aligned inverse mapping so a UUID typed into the editor is stored byte-for-byte (`Data0` <- first hex pair). `randomUUID` was already byte-aligned — unchanged.